### PR TITLE
FEAT: Makes X-Ray sidecar config file configurable.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -271,7 +271,7 @@ locals {
   xray_container = var.xray_daemon == true ? [{
     name      = "aws-otel-collector",
     image     = "amazon/aws-otel-collector",
-    command   = ["--config=/etc/ecs/ecs-default-config.yaml"]
+    command   = ["--config=/etc/ecs/${var.xray_daemon_config_path}"]
     essential = true
   }] : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -195,5 +195,5 @@ variable "xray_daemon" {
 variable "xray_daemon_config_path" {
   description = "The config file to use for the X-Ray exporter sidecar. Should be one of the files found here: https://github.com/aws-observability/aws-otel-collector/tree/main/config/ecs."
   type = string
-  default = "ecs-default-config.yaml"
+  default = "ecs-xray.yaml"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -191,3 +191,9 @@ variable "xray_daemon" {
   type        = bool
   default     = false
 }
+
+variable "xray_daemon_config_path" {
+  description = "The config file to use for the X-Ray exporter sidecar. Should be one of the files found here: https://github.com/aws-observability/aws-otel-collector/tree/main/config/ecs."
+  type = string
+  default = "ecs-default-config.yaml"
+}


### PR DESCRIPTION
Default config fila som har blitt brukt sender ikke _BARE_ XRay traces upstream. Den sender i tillegg en bråte med metrics, som ikke var helt åpenbart for oss. Disse metrikkene bruker vi ikke til noe overhodet, men det har likevel ført til en nesten 4-dobling av kost for metrikker. Legger derfor inn en mulighet for å velge en annen configfil som vi ønsker å teste ut, f.eks. [ecs-xray.yaml](https://github.com/aws-observability/aws-otel-collector/blob/main/config/ecs/ecs-xray.yaml). Default filnavn er det samme som den var før, så endringen skal være bakoverkompatibel.