### PR TITLE
support for http_header filter rules in LB listener rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -258,6 +258,13 @@ resource "aws_lb_listener_rule" "service" {
           values = [host_header.value]
         }
       }
+      dynamic "http_header" {
+        for_each = condition.value.http_header != null ? [condition.value.http_header] : []
+        content {
+          http_header_name = http_header.value.name
+          values           = http_header.value.values
+        }
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "memory" {
 }
 
 variable "lb_listeners" {
-  description = "Configuration for load balancing"
+  description = "Configuration for load balancing. Note: each condition needs to be wrapped in a separate block"
   type = list(object({
     listener_arn      = string
     security_group_id = string
@@ -57,6 +57,10 @@ variable "lb_listeners" {
     conditions = list(object({
       path_pattern = optional(string)
       host_header  = optional(string)
+      http_header = optional(object({
+        name   = string
+        values = list(string)
+      }))
     }))
   }))
   default = []
@@ -194,6 +198,6 @@ variable "xray_daemon" {
 
 variable "xray_daemon_config_path" {
   description = "The config file to use for the X-Ray exporter sidecar. Should be one of the files found here: https://github.com/aws-observability/aws-otel-collector/tree/main/config/ecs."
-  type = string
-  default = "ecs-xray.yaml"
+  type        = string
+  default     = "ecs-xray.yaml"
 }


### PR DESCRIPTION
Adds support for the http_header in the LB listener rule. 

In this case, we use it to set a header in a cloudfront distribution and filter traffic in the ALB to make sure it originates from the distribution in question. 