### PR TITLE
Add variable for enabling Amazon ECS exec for services

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,12 @@
 = Changelog
 
+== 0.11.0
+* Add variable for enabling `aws ecs exec` from AWS CLI.
+* Rename `name_prefix` to `application_name`.
+
+=== Breaking Changes
+* Rename `name_prefix` to `application_name`.
+
 == 0.8.0
 
 === Breaking Changes

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -48,7 +48,7 @@ data "aws_lb_listener" "http" {
 module "service" {
   source = "../../"
 
-  name_prefix = local.application_name
+  application_name = local.application_name
 
   vpc_id             = data.aws_vpc.main.id
   private_subnet_ids = data.aws_subnets.private.ids

--- a/examples/on-prem/main.tf
+++ b/examples/on-prem/main.tf
@@ -22,7 +22,7 @@ data "aws_ecs_cluster" "main" {
 module "service" {
   source = "../../"
 
-  name_prefix = local.application_name
+  application_name = local.application_name
 
   cluster_id = data.aws_ecs_cluster.main.id
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -48,7 +48,7 @@ data "aws_lb_listener" "http" {
 module "service" {
   source = "../../"
 
-  name_prefix = local.application_name
+  application_name = local.application_name
 
   vpc_id                   = data.aws_vpc.main.id
   private_subnet_ids       = data.aws_subnets.private.ids

--- a/main.tf
+++ b/main.tf
@@ -364,6 +364,7 @@ resource "aws_ecs_service" "service" {
   health_check_grace_period_seconds  = var.launch_type == "EXTERNAL" ? null : var.health_check_grace_period_seconds
   wait_for_steady_state              = var.wait_for_steady_state
   propagate_tags                     = var.propagate_tags
+  enable_execute_command             = var.enable_execute_command
 
   # ECS Anywhere doesn't support VPC networking or load balancers.
   # Because of this, we need to make these resources dynamic!

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
  * = Logging
  */
 resource "aws_cloudwatch_log_group" "main" {
-  name              = var.name_prefix
+  name              = var.application_name
   retention_in_days = var.log_retention_in_days
   tags              = var.tags
 }
@@ -31,12 +31,12 @@ data "aws_iam_policy_document" "task_assume" {
  * This allows the task to pull from ECR, etc
  */
 resource "aws_iam_role" "execution" {
-  name               = "${var.name_prefix}-task-execution-role"
+  name               = "${var.application_name}-task-execution-role"
   assume_role_policy = data.aws_iam_policy_document.task_assume.json
 }
 
 resource "aws_iam_role_policy" "task_execution" {
-  name   = "${var.name_prefix}-task-execution"
+  name   = "${var.application_name}-task-execution"
   role   = aws_iam_role.execution.id
   policy = data.aws_iam_policy_document.task_execution_permissions.json
 }
@@ -66,12 +66,12 @@ data "aws_iam_policy_document" "task_execution_permissions" {
  * Gives the actual containers the permissions they need
  */
 resource "aws_iam_role" "task" {
-  name               = "${var.name_prefix}-task-role"
+  name               = "${var.application_name}-task-role"
   assume_role_policy = data.aws_iam_policy_document.task_assume.json
 }
 
 resource "aws_iam_role_policy" "ecs_task_logs" {
-  name   = "${var.name_prefix}-log-permissions"
+  name   = "${var.application_name}-log-permissions"
   role   = aws_iam_role.task.id
   policy = data.aws_iam_policy_document.ecs_task_logs.json
 }
@@ -135,11 +135,11 @@ resource "aws_security_group" "ecs_service" {
   count = var.launch_type == "EXTERNAL" ? 0 : 1
 
   vpc_id      = var.vpc_id
-  name        = "${var.name_prefix}-ecs-service-sg"
+  name        = "${var.application_name}-ecs-service-sg"
   description = "Fargate service security group"
   tags = merge(
     var.tags,
-    { Name = "${var.name_prefix}-sg" }
+    { Name = "${var.application_name}-sg" }
   )
 }
 
@@ -228,7 +228,7 @@ resource "aws_lb_target_group" "service" {
 
   tags = merge(
     var.tags,
-    { Name = "${var.name_prefix}-target-${var.application_container.port}-${each.key}" }
+    { Name = "${var.application_name}-target-${var.application_container.port}-${each.key}" }
   )
 }
 
@@ -306,7 +306,7 @@ locals {
 data "aws_region" "current" {}
 
 resource "aws_ecs_task_definition" "task" {
-  family = var.name_prefix
+  family = var.application_name
   container_definitions = jsonencode([
     for container in local.containers : merge({
       name    = container.name
@@ -354,7 +354,7 @@ resource "aws_ecs_task_definition" "task" {
 }
 
 resource "aws_ecs_service" "service" {
-  name                               = var.name_prefix
+  name                               = var.application_name
   cluster                            = var.cluster_id
   task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = var.desired_count
@@ -420,7 +420,7 @@ resource "aws_appautoscaling_target" "ecs_service" {
 }
 
 resource "aws_appautoscaling_policy" "ecs_service" {
-  name = "${var.name_prefix}-automatic-scaling"
+  name = "${var.application_name}-automatic-scaling"
   # Step Scaling is also available, but it's explicitly not recommended by the AWS docs.
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.ecs_service.resource_id
@@ -449,7 +449,7 @@ resource "aws_appautoscaling_scheduled_action" "ecs_service" {
     if var.autoscaling != null
   }
 
-  name               = "${var.name_prefix}-scheduled-scaling"
+  name               = "${var.application_name}-scheduled-scaling"
   resource_id        = aws_appautoscaling_target.ecs_service.resource_id
   scalable_dimension = aws_appautoscaling_target.ecs_service.scalable_dimension
   service_namespace  = aws_appautoscaling_target.ecs_service.service_namespace

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "propagate_tags" {
   default     = "SERVICE"
 }
 
+variable "enable_execute_command" {
+  description = "Specifies whether to enable Amazon ECS Exec for the tasks within the service."
+  type        = bool
+  default     = false
+}
+
 variable "deployment_minimum_healthy_percent" {
   default     = 50
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
-variable "name_prefix" {
-  description = "A prefix used for naming resources."
+variable "application_name" {
+  description = "Name of service. Used to prefix the name of resources."
   type        = string
 }
 


### PR DESCRIPTION
Hender vi bruker denne for å gjøre dump av kjørende java-prosess i ECS. Har brukt det for å identifisere minnelekkasjer.

Renamer også name_prefix-variabelen til application_name.