### PR TITLE
Create dedicated parameter for protocol in port mapping

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -293,7 +293,7 @@ locals {
       environment       = try(container.environment, {})
       secrets           = try(container.secrets, {})
       port              = try(container.port, null)
-      protocol          = try(container.protocol, "tcp")
+      network_protocol  = try(container.network_protocol, "tcp")
       health_check      = try(container.health_check, null)
       cpu               = try(container.cpu, null)
       memory_hard_limit = try(container.memory_hard_limit, null)
@@ -326,7 +326,7 @@ resource "aws_ecs_task_definition" "task" {
       portMappings = [container.port == null ? null : {
         containerPort = tonumber(container.port)
         hostPort      = tonumber(container.port)
-        protocol      = container.protocol
+        protocol      = container.network_protocol
       }]
       logConfiguration = {
         logDriver = "awslogs"


### PR DESCRIPTION
## Background
The `protocol` parameter in the `application_container` definition is used to set both the [target group protocol](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#protocol) and the [port mapping protocol](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) of the task definition.

We need HTTP as the protocol in our target group, and because HTTP is not a valid protocol for the port mapping in the task definition, we get the following diff every time we run `terraform plan`:

```hcl
  # module.this.module.task-se.module.task.aws_ecs_task_definition.task must be replaced
-/+ resource "aws_ecs_task_definition" "task" {
      ~ container_definitions = jsonencode(
          ~ [
              ~ {
                  ~ portMappings      = [
                      ~ {
                          ~ protocol      = "tcp" -> "HTTP"
                            # (2 unchanged attributes hidden)
                        },
                    ]
                },
            ]
        )
    }
```

The reason it works is that the AWS api just sets the default value for protocol if an invalid protocol is chosen.

## Solution
Create dedicated parameter `network_protocol` for setting the protocol of the port mapping. The parameter defaults to `tcp` and this is the default that is set if an invalid parameter is set as well. So, those who need `udp` will have to set `network_protocol = 'udp'` and those who need `tcp` do not need to make any changes. So, I guess this is a breaking change for the people who use `udp`.