### PR TITLE
Add variable for timeouts for the ecs service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -451,6 +451,12 @@ resource "aws_ecs_service" "service" {
       weight            = capacity_provider_strategy.value.weight
     }
   }
+
+  timeouts {
+    create = var.ecs_service_timeouts.create
+    update = var.ecs_service_timeouts.update
+    delete = var.ecs_service_timeouts.delete
+  }
 }
 
 resource "aws_ecs_service" "service_with_autoscaling" {
@@ -506,6 +512,12 @@ resource "aws_ecs_service" "service_with_autoscaling" {
 
   lifecycle {
     ignore_changes = [desired_count]
+  }
+
+  timeouts {
+    create = var.ecs_service_timeouts.create
+    update = var.ecs_service_timeouts.update
+    delete = var.ecs_service_timeouts.delete
   }
 }
 
@@ -588,7 +600,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
 
   lifecycle {
     precondition {
-      condition = !(var.autoscaling_resource_label != "" && length(var.custom_metrics) > 0)
+      condition     = !(var.autoscaling_resource_label != "" && length(var.custom_metrics) > 0)
       error_message = "Cannot define autoscaling resource label and custom metrics at the same time"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,20 @@ variable "launch_type" {
   }
 }
 
+variable "ecs_service_timeouts" {
+  description = "The timeouts for terraform update of the ECS service"
+  type = object({
+    create = optional(string, null)
+    update = optional(string, null)
+    delete = optional(string, null)
+  })
+  default = {
+    create = "20m"
+    update = "20m"
+    delete = "20m"
+  }
+}
+
 variable "use_spot" {
   description = "NB! NOT RECOMMENDED FOR PROD. Whether to use spot instances for the service. Requirement: FARGATE_SPOT enabled capacity providers. Mutually exclusive with \"launch_type\"."
   type        = bool


### PR DESCRIPTION
This let's users control the timeout of terraform for creating services. Generally you'd need to set `update` and `create`.

It doesn't affect all resources, just the `aws_ecs_service`, so DNS validation records or other slow stuff shouldn't be affected. 

One point of discussion here is the grace-period. It is currenctly set to 300 seconds default. I'd say that you should be careful setting this one to anything below 10m withouth changing that first. Maybe the default should be lowered? 5 minutes to become healthy is pretty conservative.