### PR TITLE
Implement loadbalancer stickiness

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -261,6 +261,10 @@ resource "aws_lb_target_group" "service" {
   )
 }
 
+locals {
+  enable_stickiness = var.lb_stickiness.enabled ? 1 : null
+}
+
 resource "aws_lb_listener_rule" "service" {
   for_each = { for idx, value in var.lb_listeners : idx => value }
 
@@ -274,10 +278,10 @@ resource "aws_lb_listener_rule" "service" {
       }
 
       dynamic "stickiness" {
-        for_each = var.lb_stickiness[*]
+        for_each = local.enable_stickiness[*]
         content {
           enabled  = true
-          duration = stickiness.value.cookie_duration
+          duration = var.lb_stickiness.cookie_duration
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -234,3 +234,15 @@ variable "custom_metrics" {
   }))
   default = []
 }
+
+variable "lb_stickiness" {
+  description = "Bind a user's session to a specific target"
+  nullable    = true
+  type        = object({
+    type            = string
+    enabled         = optional(bool, null)
+    cookie_duration = optional(number, null)
+    cookie_name     = optional(string, null)
+    })
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -238,15 +238,15 @@ variable "custom_metrics" {
 variable "lb_stickiness" {
   description = "Bind a user's session to a specific target"
   nullable    = false
-  type        = object({
+  type = object({
     type            = string
     enabled         = optional(bool, null)
     cookie_duration = optional(number, null)
     cookie_name     = optional(string, null)
-    })
+  })
   default = {
     type            = "lb_cookie"
     enabled         = false
-    cookie_duration = 86400
+    cookie_duration = 86400 # 24h in seconds
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -237,12 +237,16 @@ variable "custom_metrics" {
 
 variable "lb_stickiness" {
   description = "Bind a user's session to a specific target"
-  nullable    = true
+  nullable    = false
   type        = object({
     type            = string
     enabled         = optional(bool, null)
     cookie_duration = optional(number, null)
     cookie_name     = optional(string, null)
     })
-  default = null
+  default = {
+    type            = "lb_cookie"
+    enabled         = false
+    cookie_duration = 86400
+  }
 }


### PR DESCRIPTION
Adds support for activating stickiness in the loadbalancer. Needed in order to make authenticated sessions in admin panels sticky so that user stay signed in on new requests. 

Note:
This will give a diff because of the changed structure of the listener "forward" action, however this does not any actual changes.  