### PR TITLE
Make custom_metrics.metric_stat optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -613,7 +613,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
                 stat = metric_stat.value.stat
               }
             }
-            expression = metrics.value.expression
+            expression =  metrics.value.metric_stat == null ? "foo" : null
             return_data = metrics.value.return_data
           }
         }

--- a/main.tf
+++ b/main.tf
@@ -613,7 +613,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
                 stat = metric_stat.value.stat
               }
             }
-            expression =  metrics.value.metric_stat == null ? metrics.value.expression : null
+            expression = metrics.value.expression
             return_data = metrics.value.return_data
           }
         }

--- a/main.tf
+++ b/main.tf
@@ -596,7 +596,8 @@ resource "aws_appautoscaling_policy" "ecs_service" {
           content {
             label = metrics.value.label
             id    = metrics.value.id
-            metric_stat {
+            dynamic metric_stat {
+              for_each = metrics.value.metric_stat == null ? [] : [1]
               metric {
                 metric_name = metrics.value.metric_stat.metric.metric_name
                 namespace   = metrics.value.metric_stat.metric.namespace

--- a/main.tf
+++ b/main.tf
@@ -589,7 +589,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
     }
 
     dynamic "customized_metric_specification" {
-      for_each = length(var.custom_metrics) > 0 ? [1] : []
+      for_each = var.custom_metrics[*]
       content {
         dynamic "metrics" {
           for_each = var.custom_metrics
@@ -597,20 +597,20 @@ resource "aws_appautoscaling_policy" "ecs_service" {
             label = metrics.value.label
             id    = metrics.value.id
             dynamic metric_stat {
-              for_each = metrics.value.metric_stat == null ? [] : [1]
+              for_each = metrics.value.metric_stat[*]
               content {
                 metric {
-                  metric_name = metrics.value.metric_stat.metric.metric_name
-                  namespace   = metrics.value.metric_stat.metric.namespace
+                  metric_name = metric_stat.value.metric.metric_name
+                  namespace   = metric_stat.value.metric.namespace
                   dynamic "dimensions" {
-                    for_each = metrics.value.metric_stat.metric.dimensions
+                    for_each = metric_stat.value.metric.dimensions
                     content {
                       name  = dimensions.value.name
                       value = dimensions.value.value
                     }
                   }
                 }
-                stat = metrics.value.metric_stat.stat
+                stat = metric_stat.value.stat
               }
             }
             return_data = metrics.value.return_data

--- a/main.tf
+++ b/main.tf
@@ -589,7 +589,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
     }
 
     dynamic "customized_metric_specification" {
-      for_each = var.custom_metrics[*]
+      for_each = length(var.custom_metrics) > 0 ? [1] : []
       content {
         dynamic "metrics" {
           for_each = var.custom_metrics

--- a/main.tf
+++ b/main.tf
@@ -598,18 +598,20 @@ resource "aws_appautoscaling_policy" "ecs_service" {
             id    = metrics.value.id
             dynamic metric_stat {
               for_each = metrics.value.metric_stat == null ? [] : [1]
-              metric {
-                metric_name = metrics.value.metric_stat.metric.metric_name
-                namespace   = metrics.value.metric_stat.metric.namespace
-                dynamic "dimensions" {
-                  for_each = metrics.value.metric_stat.metric.dimensions
-                  content {
-                    name  = dimensions.value.name
-                    value = dimensions.value.value
+              content {
+                metric {
+                  metric_name = metrics.value.metric_stat.metric.metric_name
+                  namespace   = metrics.value.metric_stat.metric.namespace
+                  dynamic "dimensions" {
+                    for_each = metrics.value.metric_stat.metric.dimensions
+                    content {
+                      name  = dimensions.value.name
+                      value = dimensions.value.value
+                    }
                   }
                 }
+                stat = metrics.value.metric_stat.stat
               }
-              stat = metrics.value.metric_stat.stat
             }
             return_data = metrics.value.return_data
           }

--- a/main.tf
+++ b/main.tf
@@ -613,7 +613,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
                 stat = metric_stat.value.stat
               }
             }
-            expression =  metrics.value.metric_stat == null ? "foo" : null
+            expression =  metrics.value.metric_stat == null ? metrics.value.expression : null
             return_data = metrics.value.return_data
           }
         }

--- a/main.tf
+++ b/main.tf
@@ -613,6 +613,7 @@ resource "aws_appautoscaling_policy" "ecs_service" {
                 stat = metric_stat.value.stat
               }
             }
+            expression = metrics.value.expression
             return_data = metrics.value.return_data
           }
         }

--- a/variables.tf
+++ b/variables.tf
@@ -248,6 +248,7 @@ variable "custom_metrics" {
       })
       stat = string
     }))
+    expression = optional(string, null)
     return_data = bool
   }))
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -247,7 +247,7 @@ variable "custom_metrics" {
         }))
       })
       stat = string
-    }))
+    }), null)
     expression = optional(string, null)
     return_data = bool
   }))

--- a/variables.tf
+++ b/variables.tf
@@ -237,6 +237,7 @@ variable "custom_metrics" {
   type = list(object({
     label = string
     id    = string
+    expression  = optional(string)
     metric_stat = optional(object({
       metric = object({
         metric_name = string
@@ -248,7 +249,6 @@ variable "custom_metrics" {
       })
       stat = string
     }), null)
-    expression = optional(string, null)
     return_data = bool
   }))
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -237,7 +237,7 @@ variable "custom_metrics" {
   type = list(object({
     label = string
     id    = string
-    metric_stat = object({
+    metric_stat = optional(object({
       metric = object({
         metric_name = string
         namespace   = string
@@ -247,7 +247,7 @@ variable "custom_metrics" {
         }))
       })
       stat = string
-    })
+    }))
     return_data = bool
   }))
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -248,7 +248,7 @@ variable "custom_metrics" {
         }))
       })
       stat = string
-    }), null)
+    }))
     return_data = bool
   }))
   default = []


### PR DESCRIPTION
For some metrics, like the one in [this example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy#create-target-tracking-scaling-policy-using-metric-math), we want to be able to omit the metric_stat object. 
The solution, in this PR, is to make metric_stat a dynamic block