### PR TITLE
Add scale in and scale out cooldown variables and fix forward actions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -549,6 +549,7 @@ locals {
   # The Cluster ID is the cluster's ARN.
   # The last part after a '/'is the name of the cluster.
   cluster_name = split("/", var.cluster_id)[1]
+
   autoscaling = var.autoscaling != null ? var.autoscaling : {
     min_capacity = var.desired_count
     max_capacity = var.desired_count
@@ -616,7 +617,9 @@ resource "aws_appautoscaling_policy" "ecs_service" {
       }
     }
 
-    target_value = coalesce(var.autoscaling.target_value, local.autoscaling.target_value)
+    target_value       = coalesce(var.autoscaling.target_value, local.autoscaling.target_value)
+    scale_in_cooldown  = var.autoscaling.scale_in_cooldown
+    scale_out_cooldown = var.autoscaling.scale_out_cooldown
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -269,8 +269,11 @@ resource "aws_lb_listener_rule" "service" {
   action {
     type = "forward"
     forward {
-      target_group {
-        arn = aws_lb_target_group.service[each.key].arn
+      dynamic "target_group" {
+        for_each = aws_lb_target_group.service
+        content {
+          arn = target_group.value.arn
+        }
       }
       dynamic "stickiness" {
         for_each = var.lb_stickiness.enabled ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -117,10 +117,12 @@ variable "desired_count" {
 variable "autoscaling" {
   description = "Enable autoscaling for the service"
   type = object({
-    min_capacity = number
-    max_capacity = number
-    metric_type  = string
-    target_value = string
+    min_capacity       = number
+    max_capacity       = number
+    metric_type        = string
+    target_value       = string
+    scale_in_cooldown  = optional(number, null) # in seconds
+    scale_out_cooldown = optional(number, null) # in seconds
   })
   default = null
 }


### PR DESCRIPTION
- #18 introduced a bug where you are required to specify at least two `target_groups` (`var.lb_listeners`), as the `forward` block requires it. 
However, this breaks the module for users who only specify one `lb_listeners`
- Add scale in and scale out cooldown variables for autoscaling