### PR TITLE
Bugfix containerPort after provider upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -388,8 +388,8 @@ resource "aws_ecs_task_definition" "task" {
           valueFrom = value
         }
       ]
-      portMappings = [
-        container.port == null ? null : {
+      portMappings = container.port == null ? [] : [
+        {
           containerPort = tonumber(container.port)
           hostPort      = tonumber(container.port)
           protocol      = container.network_protocol


### PR DESCRIPTION
Make task definition port mappings an empty array if the container port is null