### PR TITLE
Add log configuration to container definition (#1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -356,6 +356,14 @@ locals {
       memory_hard_limit = try(container.memory_hard_limit, null)
       memory_soft_limit = try(container.memory_soft_limit, null)
       extra_options     = try(container.extra_options, {})
+      log_configuration = try(container.log_configuration, {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group" : aws_cloudwatch_log_group.main.name,
+          "awslogs-region" : data.aws_region.current.name,
+          "awslogs-stream-prefix" : container.name
+        }
+      })
     }
   ]
   capacity_provider_strategy = {
@@ -395,14 +403,7 @@ resource "aws_ecs_task_definition" "task" {
           protocol      = container.network_protocol
         }
       ]
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          "awslogs-group" : aws_cloudwatch_log_group.main.name,
-          "awslogs-region" : data.aws_region.current.name,
-          "awslogs-stream-prefix" : container.name
-        }
-      }
+      logConfiguration  = container.log_configuration
       healthCheck       = container.health_check
       cpu               = container.cpu
       memory            = container.memory_hard_limit


### PR DESCRIPTION
* add log configuration to container definition

Adding the log configuration to the container definition allows for other drivers to be enabled, like awsfirelens.