### PR TITLE
Fix extra_ports statement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -682,7 +682,7 @@ locals {
     secrets       = merge(module.env_vars_to_ssm_parameters.ssm_parameter_arns, var.application_container.secrets_from_ssm)
     extra_options = merge(try(module.autoinstrumentation_setup[0].new_extra_options, {}), var.application_container.extra_options)
     # Extra ports are needed in cases where the Load Balancer Health Check port is different from the application containers normal ports
-    extra_ports = try(var.lb_health_check.port, null) != var.application_container.port ? [var.lb_health_check.port] : []
+    extra_ports = try(var.lb_health_check.port, null) != var.application_container.port ? compact([try(var.lb_health_check.port, null)]) : []
     }
   )
   init_container = var.datadog_instrumentation_runtime == null ? [] : [module.autoinstrumentation_setup[0].init_container_definition]


### PR DESCRIPTION
Allows `var.lb_health_check.port` to not be set