### PR TITLE
Add support for enabling Runtime Security features in DataDog

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -605,15 +605,15 @@ locals {
         DD_ENV     = local.environment
         DD_TAGS    = local.team_name_tag
 
-        DD_APM_ENABLED            = var.datadog_options.apm_enabled
+        DD_APM_ENABLED            = local.datadog_options.apm_enabled
         DD_APM_FILTER_TAGS_REJECT = "http.useragent:ELB-HealthChecker/2.0 user_agent:ELB-HealthChecker/2.0"
         # Reject anything ending in /health
         DD_APM_FILTER_TAGS_REGEX_REJECT = "http.url:.*\\/health$"
         DD_ECS_TASK_COLLECTION_ENABLED  = "true"
 
         # DATADOG Startup
-        DD_TRACE_STARTUP_LOGS            = var.datadog_options.trace_startup_logs
-        DD_TRACE_PARTIAL_FLUSH_MIN_SPANS = var.datadog_options.trace_partial_flush_min_spans
+        DD_TRACE_STARTUP_LOGS            = local.datadog_options.trace_startup_logs
+        DD_TRACE_PARTIAL_FLUSH_MIN_SPANS = local.datadog_options.trace_partial_flush_min_spans
       }, var.datadog_environment_variables),
       secrets = {
         DD_API_KEY = local.datadog_api_key_secret
@@ -657,6 +657,22 @@ locals {
     for k, v in var.application_container.environment : k => v
     if !contains(["JAVA_TOOL_OPTIONS", "NODE_OPTIONS"], k)
   }
+
+  // A bit hacky. We're basically replicating var.datadog_options
+  // but ensuring that if the user has only partially specified the properties under var.datadog_options
+  // we will use the default values for the non-specified ones.
+  //
+  // If not, all non-specified values becomes `null`. Which we don't want.
+  datadog_options = {
+    trace_startup_logs            = coalesce(var.datadog_options.trace_startup_logs, false)           # Datadog default is true.
+    trace_partial_flush_min_spans = coalesce(var.datadog_options.trace_partial_flush_min_spans, 2000) # Datadog default is 1000.
+    profiling_enabled             = coalesce(var.datadog_options.profiling_enabled, false)
+    apm_enabled                   = coalesce(var.datadog_options.apm_enabled, true)
+
+    app_protection_enabled                = coalesce(var.datadog_options.app_protection_enabled, false)
+    runtime_code_analysis                 = coalesce(var.datadog_options.runtime_code_analysis, false)
+    runtime_software_composition_analysis = coalesce(var.datadog_options.runtime_software_composition_analysis, false)
+  }
 }
 
 module "autoinstrumentation_setup" {
@@ -669,7 +685,11 @@ module "autoinstrumentation_setup" {
   dd_service           = var.service_name
   dd_env               = local.environment
   dd_team_tag          = local.team_name_tag
-  dd_profiling_enabled = var.datadog_options.profiling_enabled
+  dd_profiling_enabled = local.datadog_options.profiling_enabled
+
+  dd_runtime_code_analysis                 = local.datadog_options.runtime_code_analysis
+  dd_runtime_software_composition_analysis = local.datadog_options.runtime_software_composition_analysis
+  dd_app_protection                        = local.datadog_options.app_protection_enabled
 
   existing_java_tool_options = local.existing_java_tool_options
   existing_node_options      = local.existing_node_options
@@ -698,8 +718,7 @@ locals {
     extra_options = merge(try(module.autoinstrumentation_setup[0].new_extra_options, {}), var.application_container.extra_options)
     # Extra ports are needed in cases where the Load Balancer Health Check port is different from the application containers normal ports
     extra_ports = try(var.lb_health_check.port, null) != var.application_container.port ? compact([try(var.lb_health_check.port, null)]) : []
-    }
-  )
+  })
   init_container = var.datadog_instrumentation_runtime == null ? [] : [module.autoinstrumentation_setup[0].init_container_definition]
 
   containers = [

--- a/modules/autoinstrumentation_setup/main.tf
+++ b/modules/autoinstrumentation_setup/main.tf
@@ -60,6 +60,11 @@ locals {
         DD_SERVICE = var.dd_service
         DD_ENV     = var.dd_env
         DD_TAGS    = var.dd_team_tag
+
+        // Different runtime security features that can be enabled in the service
+        DD_IAST_ENABLED       = var.dd_runtime_code_analysis
+        DD_APPSEC_SCA_ENABLED = var.dd_runtime_software_composition_analysis
+        DD_APPSEC_ENABLED     = var.dd_app_protection
       }
       extra_options = {
         dependsOn = [
@@ -86,6 +91,11 @@ locals {
 
         DD_SERVICE = var.dd_service
         DD_ENV     = var.dd_env
+
+        // Different runtime security features that can be enabled in the service
+        DD_IAST_ENABLED       = var.dd_runtime_code_analysis
+        DD_APPSEC_SCA_ENABLED = var.dd_runtime_software_composition_analysis
+        DD_APPSEC_ENABLED     = var.dd_app_protection
       }
       extra_options = {
         dependsOn = [

--- a/modules/autoinstrumentation_setup/variables.tf
+++ b/modules/autoinstrumentation_setup/variables.tf
@@ -21,6 +21,21 @@ variable "dd_profiling_enabled" {
   type        = bool
 }
 
+variable "dd_app_protection" {
+  description = "Enable Datadog App & API Protection"
+  type        = bool
+}
+
+variable "dd_runtime_code_analysis" {
+  description = "Enable Datadog IAST"
+  type        = bool
+}
+
+variable "dd_runtime_software_composition_analysis" {
+  description = "Enable Datadog's Runtime SCA"
+  type        = bool
+}
+
 variable "existing_java_tool_options" {
   description = "Existing JAVA_TOOL_OPTIONS value to append Datadog javaagent to"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -402,19 +402,25 @@ variable "datadog_instrumentation_runtime" {
 }
 
 variable "datadog_options" {
-  description = "Options for the Datadog Agent Extension"
+  description = "Options for the Datadog Agent Extension. Include the properties you want to modify, the others will use a default value"
   type = object({
-    trace_startup_logs            = optional(bool)
-    trace_partial_flush_min_spans = optional(number)
-    profiling_enabled             = optional(bool)
-    apm_enabled                   = optional(bool)
+    trace_startup_logs                    = optional(bool)
+    trace_partial_flush_min_spans         = optional(number)
+    profiling_enabled                     = optional(bool)
+    apm_enabled                           = optional(bool)
+    appsec_enabled                        = optional(bool)
+    runtime_code_analysis                 = optional(bool)
+    runtime_software_composition_analysis = optional(bool)
+    app_protection_enabled                = optional(bool)
   })
   default = {
-    trace_startup_logs            = false # Datadog default is true.
-    trace_partial_flush_min_spans = 2000  # Datadog default is 1000.
-    profiling_enabled             = false
-    apm_enabled                   = true
-    # We set 2000 so the smallest vCPU instances can handle it.
+    trace_startup_logs                    = false # Datadog default is true.
+    trace_partial_flush_min_spans         = 2000  # Datadog default is 1000.
+    profiling_enabled                     = false
+    apm_enabled                           = true
+    app_protection_enabled                = false
+    runtime_code_analysis                 = false
+    runtime_software_composition_analysis = false
   }
 }
 


### PR DESCRIPTION
Useful for teams to get better insight into their
security risks. 

It's disabled by default, because of the "cost potential"