### PR TITLE
Delete moved.tf

### DIFF
--- a/moved.tf
+++ b/moved.tf
@@ -1,6 +1,0 @@
-# For module version 3.0.0-rc7 -> 3.0.0-rc8
-# Own module for autoscaling is no longer needed as we ignore changes to desired_count as
-moved {
-  from = aws_ecs_service.service_with_autoscaling[0]
-  to   = aws_ecs_service.service[0]
-}


### PR DESCRIPTION
Gjør det vanskelig å migrere terraform som bruker denne modulen. Antar den ikke trengs lenger. I så fall kan folk gå via en eldre versjon. 