### PR TITLE
Added reservation for cpu and memory.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -30,7 +30,8 @@ locals {
       image             = "public.ecr.aws/datadog/agent:7",
       essential         = true,
       cpu               = 64,
-      memory_hard_limit = 256,
+      memory_soft_limit = 256,
+      memory_hard_limit = 512,
 
       environment = merge({
         ECS_FARGATE = "true"
@@ -67,7 +68,8 @@ locals {
       image             = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
       essential         = true,
       cpu               = 64,
-      memory_hard_limit = 256,
+      memory_soft_limit = 256,
+      memory_hard_limit = 512,
 
       extra_options = {
         firelensConfiguration = {

--- a/ecs.tf
+++ b/ecs.tf
@@ -27,9 +27,9 @@ locals {
       // while ensuring that these agents are running the latest (patched) version.
       //
       // Consider to revisit this approach in the future.
-      image     = "public.ecr.aws/datadog/agent:7",
-      essential = true,
-      cpu       = 64,
+      image             = "public.ecr.aws/datadog/agent:7",
+      essential         = true,
+      cpu               = 64,
       memory_hard_limit = 256,
 
       environment = merge({
@@ -63,10 +63,10 @@ locals {
       }
     },
     {
-      name      = "log-router",
-      image     = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
-      essential = true,
-      cpu       = 64,
+      name              = "log-router",
+      image             = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+      essential         = true,
+      cpu               = 64,
       memory_hard_limit = 256,
 
       extra_options = {

--- a/ecs.tf
+++ b/ecs.tf
@@ -29,6 +29,8 @@ locals {
       // Consider to revisit this approach in the future.
       image     = "public.ecr.aws/datadog/agent:7",
       essential = true,
+      cpu       = 64,
+      memory_hard_limit = 256,
 
       environment = merge({
         ECS_FARGATE = "true"
@@ -64,6 +66,8 @@ locals {
       name      = "log-router",
       image     = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
       essential = true,
+      cpu       = 64,
+      memory_hard_limit = 256,
 
       extra_options = {
         firelensConfiguration = {


### PR DESCRIPTION
Memory and CPU reservations for `datadog-agent` and `log-router` got removed after we upgraded to GHA. We don't know why - magic? No. Humans tend to forget.

Adding back CPU and Memory reservation for `datadog-agent` and `log-router`.