### PR TITLE
FEAT: Fixes Datadog on EXTERNAL launch_type

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -10,7 +10,7 @@ locals {
   # task. Both the Datadog Agent and the FireLens log router have to be wired up differently
   # because of it -- see the comments further down.
   network_mode           = var.launch_type == "EXTERNAL" ? "bridge" : "awsvpc"
-  is_bridge_network_mode = var.launch_type == "EXTERNAL"
+  is_bridge_network_mode = local.network_mode == "bridge"
 
   xray_container = var.xray_daemon == true ? [
     {

--- a/ecs.tf
+++ b/ecs.tf
@@ -54,26 +54,6 @@ locals {
     },
   ]
 
-  # Whether to route container logs to Datadog through the FireLens sidecar, or straight to
-  # CloudWatch with the awslogs driver.
-  #
-  # This is off by default in bridge mode because FireLens needs an ECS container agent of at
-  # least v1.93.0 there. Older agents unconditionally pass the fluentd-async-connect log
-  # option, which Docker deprecated in 20.10.0 and removed in 28.0.0, so on a modern Docker
-  # every container using the awsfirelens driver fails to create with:
-  #   CannotCreateContainerError: unknown log opt 'fluentd-async-connect' for fluentd log driver
-  # v1.93.0 picks the option based on the Docker server version instead:
-  # https://github.com/aws/amazon-ecs-agent/pull/4558
-  #
-  # Note that ECS_ENABLE_FIRELENS_ASYNC=false does not help on an older agent -- it still
-  # writes the key, only with the value "false", and the daemon rejects the key itself.
-  #
-  # Check what an instance is running with:
-  #   aws ecs describe-container-instances --cluster <cluster> --container-instances <arn> \
-  #     --query 'containerInstances[].versionInfo'
-  # and set datadog_options.firelens_logs_enabled = true once it reports >= 1.93.0.
-  datadog_firelens_enabled = var.enable_datadog == true && local.datadog_options.firelens_logs_enabled
-
   datadog_containers = var.enable_datadog == true ? [
     {
       name = "datadog-agent",
@@ -136,9 +116,18 @@ locals {
         startPeriod = 15
       }
     },
-    # Dropped from the task entirely when logs go to CloudWatch instead. Kept as a null so this
-    # stays a two element tuple -- see the note where datadog_containers is consumed below.
-    local.datadog_firelens_enabled ? {
+    # Requires an ECS container agent of at least v1.93.0 on the container instance whenever the
+    # task runs in bridge mode (launch_type = "EXTERNAL"). Older agents unconditionally pass the
+    # fluentd-async-connect log option, which Docker deprecated in 20.10.0 and removed in 28.0.0,
+    # so on a modern Docker every container using the awsfirelens driver fails to create with:
+    #   CannotCreateContainerError: unknown log opt 'fluentd-async-connect' for fluentd log driver
+    # v1.93.0 picks the option based on the Docker server version instead:
+    # https://github.com/aws/amazon-ecs-agent/pull/4558
+    #
+    # Check an instance with:
+    #   aws ecs describe-container-instances --cluster <cluster> --container-instances <arn> \
+    #     --query 'containerInstances[].versionInfo'
+    {
       name              = "log-router",
       image             = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
       essential         = true,
@@ -180,7 +169,7 @@ locals {
           }
         }
       }
-    } : null
+    }
   ] : null
 }
 
@@ -209,9 +198,6 @@ locals {
     app_protection_enabled                = coalesce(var.datadog_options.app_protection_enabled, false)
     runtime_code_analysis                 = coalesce(var.datadog_options.runtime_code_analysis, false)
     runtime_software_composition_analysis = coalesce(var.datadog_options.runtime_software_composition_analysis, false)
-
-    # Defaults to off in bridge mode, on everywhere else. See local.datadog_firelens_enabled.
-    firelens_logs_enabled = coalesce(var.datadog_options.firelens_logs_enabled, !local.is_bridge_network_mode)
   }
 }
 
@@ -468,13 +454,9 @@ resource "aws_ecs_task_definition" "task_datadog" {
         ]
       )
 
-      # Built with merge() rather than one ternary over two whole objects, because the two
-      # branches have different keys (only FireLens takes secretOptions) and Terraform can't
-      # unify those into a single conditional result type.
-      logConfiguration = merge({
-        logDriver = local.datadog_firelens_enabled ? "awsfirelens" : "awslogs"
-
-        options = local.datadog_firelens_enabled ? {
+      logConfiguration = {
+        logDriver = "awsfirelens",
+        options = {
           Name       = "datadog",
           Host       = "http-intake.logs.datadoghq.eu",
           compress   = "gzip",
@@ -483,22 +465,14 @@ resource "aws_ecs_task_definition" "task_datadog" {
           dd_service = var.dd_service_name_override != null ? var.dd_service_name_override : var.service_name,
           # Version tag should be appended dynamically in GitHub Actions
           dd_tags = join(",", compact([local.team_name_tag, "env:${local.environment}", "version:${var.application_container.image.git_sha}"]))
-          } : {
-          "awslogs-group"         = aws_cloudwatch_log_group.main.name
-          "awslogs-region"        = data.aws_region.current.region
-          "awslogs-stream-prefix" = container.name
         }
-        },
-        # Only FireLens needs the API key to talk to the Datadog intake; awslogs has no secrets.
-        local.datadog_firelens_enabled ? {
-          secretOptions = [
-            {
-              name      = "apiKey",
-              valueFrom = local.datadog_api_key_secret
-            }
-          ]
-        } : {},
-      )
+        secretOptions = [
+          {
+            name      = "apiKey",
+            valueFrom = local.datadog_api_key_secret
+          }
+        ]
+      }
 
       healthCheck       = container.health_check
       stopTimeout       = container.stop_timeout

--- a/ecs.tf
+++ b/ecs.tf
@@ -54,6 +54,26 @@ locals {
     },
   ]
 
+  # Whether to route container logs to Datadog through the FireLens sidecar, or straight to
+  # CloudWatch with the awslogs driver.
+  #
+  # This is off by default in bridge mode because FireLens needs an ECS container agent of at
+  # least v1.93.0 there. Older agents unconditionally pass the fluentd-async-connect log
+  # option, which Docker deprecated in 20.10.0 and removed in 28.0.0, so on a modern Docker
+  # every container using the awsfirelens driver fails to create with:
+  #   CannotCreateContainerError: unknown log opt 'fluentd-async-connect' for fluentd log driver
+  # v1.93.0 picks the option based on the Docker server version instead:
+  # https://github.com/aws/amazon-ecs-agent/pull/4558
+  #
+  # Note that ECS_ENABLE_FIRELENS_ASYNC=false does not help on an older agent -- it still
+  # writes the key, only with the value "false", and the daemon rejects the key itself.
+  #
+  # Check what an instance is running with:
+  #   aws ecs describe-container-instances --cluster <cluster> --container-instances <arn> \
+  #     --query 'containerInstances[].versionInfo'
+  # and set datadog_options.firelens_logs_enabled = true once it reports >= 1.93.0.
+  datadog_firelens_enabled = var.enable_datadog == true && local.datadog_options.firelens_logs_enabled
+
   datadog_containers = var.enable_datadog == true ? [
     {
       name = "datadog-agent",
@@ -116,7 +136,9 @@ locals {
         startPeriod = 15
       }
     },
-    {
+    # Dropped from the task entirely when logs go to CloudWatch instead. Kept as a null so this
+    # stays a two element tuple -- see the note where datadog_containers is consumed below.
+    local.datadog_firelens_enabled ? {
       name              = "log-router",
       image             = "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
       essential         = true,
@@ -158,7 +180,7 @@ locals {
           }
         }
       }
-    }
+    } : null
   ] : null
 }
 
@@ -187,6 +209,9 @@ locals {
     app_protection_enabled                = coalesce(var.datadog_options.app_protection_enabled, false)
     runtime_code_analysis                 = coalesce(var.datadog_options.runtime_code_analysis, false)
     runtime_software_composition_analysis = coalesce(var.datadog_options.runtime_software_composition_analysis, false)
+
+    # Defaults to off in bridge mode, on everywhere else. See local.datadog_firelens_enabled.
+    firelens_logs_enabled = coalesce(var.datadog_options.firelens_logs_enabled, !local.is_bridge_network_mode)
   }
 }
 
@@ -380,7 +405,7 @@ resource "aws_ecs_task_definition" "task" {
         logDriver = "awslogs"
         options = {
           "awslogs-group" : aws_cloudwatch_log_group.main.name,
-          "awslogs-region" : data.aws_region.current.region, # AWS Provider >= 6.0.0
+          "awslogs-region" : data.aws_region.current.region,
           "awslogs-stream-prefix" : container.name
         }
       }
@@ -443,9 +468,13 @@ resource "aws_ecs_task_definition" "task_datadog" {
         ]
       )
 
-      logConfiguration = {
-        logDriver = "awsfirelens",
-        options = {
+      # Built with merge() rather than one ternary over two whole objects, because the two
+      # branches have different keys (only FireLens takes secretOptions) and Terraform can't
+      # unify those into a single conditional result type.
+      logConfiguration = merge({
+        logDriver = local.datadog_firelens_enabled ? "awsfirelens" : "awslogs"
+
+        options = local.datadog_firelens_enabled ? {
           Name       = "datadog",
           Host       = "http-intake.logs.datadoghq.eu",
           compress   = "gzip",
@@ -454,14 +483,22 @@ resource "aws_ecs_task_definition" "task_datadog" {
           dd_service = var.dd_service_name_override != null ? var.dd_service_name_override : var.service_name,
           # Version tag should be appended dynamically in GitHub Actions
           dd_tags = join(",", compact([local.team_name_tag, "env:${local.environment}", "version:${var.application_container.image.git_sha}"]))
+          } : {
+          "awslogs-group"         = aws_cloudwatch_log_group.main.name
+          "awslogs-region"        = data.aws_region.current.region
+          "awslogs-stream-prefix" = container.name
         }
-        secretOptions = [
-          {
-            name      = "apiKey",
-            valueFrom = local.datadog_api_key_secret
-          }
-        ]
-      }
+        },
+        # Only FireLens needs the API key to talk to the Datadog intake; awslogs has no secrets.
+        local.datadog_firelens_enabled ? {
+          secretOptions = [
+            {
+              name      = "apiKey",
+              valueFrom = local.datadog_api_key_secret
+            }
+          ]
+        } : {},
+      )
 
       healthCheck       = container.health_check
       stopTimeout       = container.stop_timeout

--- a/ecs.tf
+++ b/ecs.tf
@@ -272,13 +272,13 @@ locals {
   # instance and would fight over a fixed host port. ECS converts every link into an implicit
   # dependsOn/START, so the Agent is already running before the application starts.
   # See the "Handle ordering for Links" block in aws/amazon-ecs-agent agent/api/task/task.go.
-  datadog_bridge_wiring_enabled = var.enable_datadog == true && local.is_bridge_network_mode
+  is_datadog_bridge_wiring_enabled = var.enable_datadog == true && local.is_bridge_network_mode
 
-  datadog_bridge_app_environment = local.datadog_bridge_wiring_enabled ? {
+  datadog_bridge_app_environment = local.is_datadog_bridge_wiring_enabled ? {
     DD_AGENT_HOST = "datadog-agent"
   } : {}
 
-  datadog_bridge_app_links = local.datadog_bridge_wiring_enabled ? distinct(concat(
+  datadog_bridge_app_links = local.is_datadog_bridge_wiring_enabled ? distinct(concat(
     try(tolist(var.application_container.extra_options.links), []),
     ["datadog-agent"],
   )) : []

--- a/ecs.tf
+++ b/ecs.tf
@@ -3,6 +3,15 @@
  */
 
 locals {
+  # ECS Anywhere can't have "awsvpc" as the network mode.
+  #
+  # Bridge mode is not just a different value here: every container gets its own network
+  # namespace and its own IP, so "localhost" no longer reaches the other containers in the
+  # task. Both the Datadog Agent and the FireLens log router have to be wired up differently
+  # because of it -- see the comments further down.
+  network_mode           = var.launch_type == "EXTERNAL" ? "bridge" : "awsvpc"
+  is_bridge_network_mode = var.launch_type == "EXTERNAL"
+
   xray_container = var.xray_daemon == true ? [
     {
       name      = "aws-otel-collector",
@@ -16,6 +25,34 @@ locals {
   split_alias       = split("-", data.aws_iam_account_alias.this.account_alias)
   environment_index = length(local.split_alias) - 1
   environment       = local.split_alias[local.environment_index]
+
+  # Outside of Fargate the Agent talks to the local Docker daemon instead of the task
+  # metadata endpoint, so it needs these host paths to run its Docker and container checks.
+  # Taken from Datadog's ECS-on-EC2 task definition. Declared as task volumes on
+  # aws_ecs_task_definition.task_datadog below.
+  datadog_agent_host_volumes = {
+    datadog-docker-socket = "/var/run/docker.sock"
+    datadog-proc          = "/proc/"
+    datadog-cgroup        = "/sys/fs/cgroup/"
+  }
+
+  datadog_agent_host_mount_points = [
+    {
+      sourceVolume  = "datadog-docker-socket"
+      containerPath = "/var/run/docker.sock"
+      readOnly      = true
+    },
+    {
+      sourceVolume  = "datadog-proc"
+      containerPath = "/host/proc/"
+      readOnly      = true
+    },
+    {
+      sourceVolume  = "datadog-cgroup"
+      containerPath = "/host/sys/fs/cgroup/"
+      readOnly      = true
+    },
+  ]
 
   datadog_containers = var.enable_datadog == true ? [
     {
@@ -34,8 +71,6 @@ locals {
       memory_hard_limit = 512,
 
       environment = merge({
-        ECS_FARGATE = "true"
-
         DD_SITE = "datadoghq.eu"
 
         DD_SERVICE = var.dd_service_name_override != null ? var.dd_service_name_override : var.service_name
@@ -51,10 +86,28 @@ locals {
         # DATADOG Startup
         DD_TRACE_STARTUP_LOGS            = local.datadog_options.trace_startup_logs
         DD_TRACE_PARTIAL_FLUSH_MIN_SPANS = local.datadog_options.trace_partial_flush_min_spans
-      }, var.datadog_environment_variables),
+        },
+        # ECS_FARGATE puts the Agent in Fargate mode, where it reads container metadata from
+        # the task metadata endpoint and skips its Docker check. That is only correct for
+        # Fargate/awsvpc tasks -- an ECS Anywhere task runs on a real Docker host, where the
+        # Agent should use the socket and host paths in datadog_agent_host_mount_points.
+        local.is_bridge_network_mode ? {} : { ECS_FARGATE = "true" },
+        # The Agent binds its APM and DogStatsD listeners to loopback only. In awsvpc the
+        # whole task shares one network namespace so that is enough, but in bridge mode the
+        # application container's traffic arrives on the Agent's bridge IP and is refused
+        # unless non-local traffic is allowed.
+        local.is_bridge_network_mode ? {
+          DD_APM_NON_LOCAL_TRAFFIC       = "true"
+          DD_DOGSTATSD_NON_LOCAL_TRAFFIC = "true"
+        } : {},
+        var.datadog_environment_variables
+      ),
       secrets = {
         DD_API_KEY = local.datadog_api_key_secret
       }
+      extra_options = local.is_bridge_network_mode ? {
+        mountPoints = local.datadog_agent_host_mount_points
+      } : {}
       health_check = {
         command     = ["CMD-SHELL", "agent health"]
         interval    = 10
@@ -82,6 +135,28 @@ locals {
         }
         # Bug: To avoid recreation of the task definition: https://github.com/hashicorp/terraform-provider-aws/pull/41394
         user = "0"
+
+        # The log router must not route its own logs through itself. Overrides the awsfirelens
+        # logConfiguration that aws_ecs_task_definition.task_datadog applies to every container.
+        #
+        # In awsvpc the ECS agent hardcodes the fluentd address to 127.0.0.1, so the router
+        # logging to itself is a silent no-op. In bridge mode the agent instead has to resolve
+        # the router's own bridge IP, which does not exist yet when the router is being created
+        # -- and it refuses to make the router wait for itself. Creating the container then
+        # fails with "DockerClientConfigError: unable to get BridgeIP for task in bridge mode",
+        # and because the router is essential the whole task dies.
+        # See addFirelensContainerDependency() in aws/amazon-ecs-agent agent/api/task/task.go.
+        #
+        # CloudWatch is also where you want these logs: if FluentBit is broken, its own
+        # diagnostics should not depend on FluentBit.
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            "awslogs-group"         = aws_cloudwatch_log_group.main.name
+            "awslogs-region"        = data.aws_region.current.region
+            "awslogs-stream-prefix" = "log-router"
+          }
+        }
       }
     }
   ] : null
@@ -177,13 +252,42 @@ locals {
     var.application_container.secrets_from_ssm,
   )
 
+  # The tracer defaults to sending to localhost:8126. In awsvpc the whole task shares one
+  # network namespace so that reaches the Agent, but in bridge mode "localhost" is the
+  # application container itself and the traces are dropped silently.
+  #
+  # A Docker link gives the application a resolvable hostname for the Agent without
+  # publishing any host ports -- which matters on ECS Anywhere, where several tasks share an
+  # instance and would fight over a fixed host port. ECS converts every link into an implicit
+  # dependsOn/START, so the Agent is already running before the application starts.
+  # See the "Handle ordering for Links" block in aws/amazon-ecs-agent agent/api/task/task.go.
+  datadog_bridge_wiring_enabled = var.enable_datadog == true && local.is_bridge_network_mode
+
+  datadog_bridge_app_environment = local.datadog_bridge_wiring_enabled ? {
+    DD_AGENT_HOST = "datadog-agent"
+  } : {}
+
+  datadog_bridge_app_links = local.datadog_bridge_wiring_enabled ? distinct(concat(
+    try(tolist(var.application_container.extra_options.links), []),
+    ["datadog-agent"],
+  )) : []
+
   # Override application container keys
   application_container_with_overrides = merge(var.application_container, {
     image = "${var.application_container.image.ecr_repository_uri}:${var.application_container.image.git_sha}"
 
-    environment   = merge(local.environment_variables, local.autoinstrumented_environment_variables)
-    secrets       = merge(local.ssm_secrets, local.secrets_from_secretsmanager)
-    extra_options = merge(try(module.autoinstrumentation_setup[0].new_extra_options, {}), var.application_container.extra_options)
+    environment = merge(
+      local.environment_variables,
+      local.autoinstrumented_environment_variables,
+      local.datadog_bridge_app_environment,
+    )
+    secrets = merge(local.ssm_secrets, local.secrets_from_secretsmanager)
+    extra_options = merge(
+      try(module.autoinstrumentation_setup[0].new_extra_options, {}),
+      var.application_container.extra_options,
+      # Merged last so a caller-supplied links list is extended rather than replaced.
+      length(local.datadog_bridge_app_links) == 0 ? {} : { links = local.datadog_bridge_app_links },
+    )
     # Extra ports are needed in cases where the Load Balancer Health Check port is different from the application containers normal ports
     extra_ports = try(var.lb_health_check.port, null) != var.application_container.port ? compact([try(var.lb_health_check.port, null)]) : []
   })
@@ -299,8 +403,7 @@ resource "aws_ecs_task_definition" "task" {
   requires_compatibilities = [var.launch_type]
   cpu                      = var.cpu
   memory                   = var.memory
-  # ECS Anywhere can't have "awsvpc" as the network mode
-  network_mode = var.launch_type == "EXTERNAL" ? "bridge" : "awsvpc"
+  network_mode             = local.network_mode
 }
 
 resource "aws_ecs_task_definition" "task_datadog" {
@@ -384,8 +487,7 @@ resource "aws_ecs_task_definition" "task_datadog" {
   requires_compatibilities = [var.launch_type]
   cpu                      = var.cpu
   memory                   = var.memory
-  # ECS Anywhere can't have "awsvpc" as the network mode
-  network_mode = var.launch_type == "EXTERNAL" ? "bridge" : "awsvpc"
+  network_mode             = local.network_mode
 
   dynamic "volume" {
     for_each = var.datadog_instrumentation_runtime != null ? [1] : []
@@ -393,6 +495,17 @@ resource "aws_ecs_task_definition" "task_datadog" {
     content {
       configure_at_launch = false
       name                = "datadog-instrumentation-init"
+    }
+  }
+
+  # Host paths the Agent needs when it is not running in Fargate mode.
+  dynamic "volume" {
+    for_each = local.is_bridge_network_mode ? local.datadog_agent_host_volumes : {}
+
+    content {
+      configure_at_launch = false
+      name                = volume.key
+      host_path           = volume.value
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -428,6 +428,17 @@ variable "datadog_options" {
     runtime_code_analysis                 = optional(bool)
     runtime_software_composition_analysis = optional(bool)
     app_protection_enabled                = optional(bool)
+
+    # Ship container logs to Datadog through a FireLens (FluentBit) sidecar.
+    #
+    # Left unset this is true everywhere except launch_type = "EXTERNAL", where FireLens needs
+    # an ECS container agent of at least v1.93.0 on the instance. Set it to true explicitly
+    # once your ECS Anywhere instances have been upgraded -- see local.datadog_firelens_enabled
+    # in ecs.tf for the details.
+    #
+    # When false the containers log to CloudWatch instead, and only traces, metrics and
+    # profiles reach Datadog.
+    firelens_logs_enabled = optional(bool)
   })
   default = {
     trace_startup_logs                    = false # Datadog default is true.

--- a/variables.tf
+++ b/variables.tf
@@ -428,17 +428,6 @@ variable "datadog_options" {
     runtime_code_analysis                 = optional(bool)
     runtime_software_composition_analysis = optional(bool)
     app_protection_enabled                = optional(bool)
-
-    # Ship container logs to Datadog through a FireLens (FluentBit) sidecar.
-    #
-    # Left unset this is true everywhere except launch_type = "EXTERNAL", where FireLens needs
-    # an ECS container agent of at least v1.93.0 on the instance. Set it to true explicitly
-    # once your ECS Anywhere instances have been upgraded -- see local.datadog_firelens_enabled
-    # in ecs.tf for the details.
-    #
-    # When false the containers log to CloudWatch instead, and only traces, metrics and
-    # profiles reach Datadog.
-    firelens_logs_enabled = optional(bool)
   })
   default = {
     trace_startup_logs                    = false # Datadog default is true.


### PR DESCRIPTION
Bakgrunn: grunnet bridge network mode på ECS Anywhere/EXTERNAL launch type fungerer det ikke å slå på Datadog i eksisterence modul. Har brukt KI assistanse til å implementere en fiks for dette.

Mulig man ønsker å kutte ned litt på Claude sine inline kommentarer - lar det bli opp til reviewers. Merk at endringen _vil_ gi diff også på vanlige Fargate deployments - dette fordi loggene til log-router flyttes til CloudWatch (veldig vanskelig å debugge den komponenten om den feiler når loggene gikk til seg selv 😓). Limer inn forklaringen på endringene nederst her:

# Fix Datadog on `launch_type = "EXTERNAL"` (ECS Anywhere)

Enabling `enable_datadog = true` on a service with `launch_type = "EXTERNAL"` produced a task
that could never start. `EXTERNAL` forces `network_mode = "bridge"`, and two assumptions in the
Datadog path only hold for `awsvpc`. A third problem turned out to be on the container instances
rather than in this module — see **Prerequisite** below.

Fargate/awsvpc consumers are unaffected apart from one deliberate change, noted at the bottom.

## 1. The log router was logging through itself

`aws_ecs_task_definition.task_datadog` applied `logDriver = "awsfirelens"` to *every* container,
including `log-router` itself.

In `awsvpc` the ECS agent hardcodes the fluentd address to `127.0.0.1`, so this is a silent
no-op. In `bridge` the agent has to resolve the router's own bridge IP, which doesn't exist yet
at create time — and it deliberately refuses to make the router wait for itself
(`addFirelensContainerDependency()`). The router is `essential`, so the task died with:

    DockerClientConfigError: unable to get BridgeIP for task in bridge mode

**Fix:** `log-router` now gets an explicit `awslogs` log configuration. Its own diagnostics no
longer depend on FluentBit being healthy.

## 2. In bridge mode nothing could reach the Agent

Each container has its own netns, so `localhost:8126` in the app container is the app container.
Scoped to `EXTERNAL` only:

- `ECS_FARGATE = "true"` is no longer set — it put the Agent in Fargate mode on a real Docker host.
- Added `DD_APM_NON_LOCAL_TRAFFIC` / `DD_DOGSTATSD_NON_LOCAL_TRAFFIC`; the Agent binds loopback only.
- Added the Agent's ECS-on-EC2 host mounts (`docker.sock`, `/host/proc`, `/host/sys/fs/cgroup`) and matching task volumes.
- App container gets `DD_AGENT_HOST = "datadog-agent"` and `links = ["datadog-agent"]`.

`links` rather than host port mappings: several tasks share an ECS Anywhere instance and would
collide on a fixed host 8126/8125. ECS converts each link into an implicit `dependsOn`/`START`,
so the Agent is up before the app. A caller-supplied `links` list is extended, not replaced.

## Prerequisite: ECS agent >= v1.93.0 on the instances

With the above fixed, container creation still failed on our current fleet:

    CannotCreateContainerError: unknown log opt 'fluentd-async-connect' for fluentd log driver

ECS agents before v1.93.0 write `fluentd-async-connect` unconditionally; Docker deprecated it in
20.10.0 and **removed it in 28.0.0**. v1.93.0 picks the option based on the Docker server version
(aws/amazon-ecs-agent#4558). The instance we tested on ran **agent 1.86.3 with Docker 29.5.2** —
an incompatible pairing. This is not fixable from Terraform, and
`ECS_ENABLE_FIRELENS_ASYNC=false` does not help either: the old agent still writes the key, just
with value `"false"`, and the daemon rejects the key itself.

The ECS Anywhere instances are being upgraded, so this PR keeps FireLens unconditional whenever
Datadog is enabled. The requirement is recorded as a comment above the `log-router` definition so
the next person to register an instance knows about it, along with the command to check a running
instance:

    aws ecs describe-container-instances --cluster <cluster> --container-instances <arn> \
      --query 'containerInstances[].versionInfo'

**Merge order matters:** deploying an `EXTERNAL` + Datadog service before its instances are on
agent >= v1.93.0 will still fail with the error above.

## Also

`network_mode` was a duplicated ternary in both task definition resources; it is now
`local.network_mode`.

## Testing

`terraform fmt` and `terraform validate` clean. Since `validate` only type-checks, the rendered
`container_definitions` JSON was diffed for both launch types:

- **EXTERNAL** — 4 containers; `awsfirelens` everywhere except `log-router` on `awslogs`; app
  container has `links` + `DD_AGENT_HOST` and keeps its `dependsOn: init:SUCCESS`; Agent has the
  3 host mounts and both non-local-traffic flags and no `ECS_FARGATE`.
- **FARGATE** — unchanged from `main` except the `log-router` log driver; `ECS_FARGATE` still set,
  no bridge wiring, no host mounts.

Also verified that a caller-supplied `extra_options.links` list is merged rather than replaced.

## Behaviour change for existing consumers

`log-router`'s own logs move from Datadog to CloudWatch for **all** Datadog-enabled services,
including Fargate (item 1 is not gated on network mode, since the router logging through itself
is wrong everywhere). This shows up as a task definition diff on the next apply. Everything else
in this PR is behind `launch_type == "EXTERNAL"`.